### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 *Seamlessly integrate QuantConnect's research environment, statistical analysis, and portfolio optimization into your AI workflows*
 
+<a href="https://glama.ai/mcp/servers/@taylorwilsdon/quantconnect-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@taylorwilsdon/quantconnect-mcp/badge" alt="QuantConnect Server MCP server" />
+</a>
+
 [◉ Quick Start](#-quick-start) •
 [◉ Documentation](#-comprehensive-api-reference) •
 [◉ Architecture](#-architecture) •
@@ -32,7 +36,7 @@ Transform your algorithmic trading research with a **production-ready MCP server
 - **▪ Enterprise Security**: SHA-256 authenticated API integration with QuantConnect
 - **⚡ High Performance**: Async-first design with concurrent data processing
 
-## ◉ Table of Contents
+## ◈ Table of Contents
 
 - [◈ Quick Start](#-quick-start)
 - [◈ Installation](#-installation)


### PR DESCRIPTION
This PR adds a badge for the [QuantConnect MCP Server](https://glama.ai/mcp/servers/@taylorwilsdon/quantconnect-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@taylorwilsdon/quantconnect-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@taylorwilsdon/quantconnect-mcp/badge" alt="QuantConnect Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.