### PR TITLE
feat & fix: add quantconnect / lean to deps for siloed install, add compile tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@
 <div align="center">
 <img width="25%" height="25%" alt="image" src="https://github.com/user-attachments/assets/f282cb1e-7fde-4efd-b28c-2656c9f48fea" />
 </div>
-Maybe? Either way, the world is changing and this is where we're at. 
+Maybe? Either way, the world is changing and this is where we're at.
 Out of the box, QuantConnect MCP provides you with:
 
-- **Full Project Lifecycle**: `Create`, `read`, `update`, and manage QuantConnect projects and files programmatically.
-- **End-to-End Backtesting**: `Create backtests` from compiles, `read detailed results`, and analyze `charts`, `orders`, and `insights`.
+- **Full Project Lifecycle**: `Create`, `read`, `update`, `compile`, and manage QuantConnect projects and files programmatically.
+- **End-to-End Backtesting**: `Compile` projects, `create backtests`, `read detailed results`, and analyze `charts`, `orders`, and `insights`.
 - **Interactive Research**: Full `QuantBook` integration for dynamic financial analysis, including historical and `alternative data` retrieval.
 - **Advanced Analytics**: Perform `Principal Component Analysis (PCA)`, `Engle-Granger cointegration tests`, `mean-reversion analysis`, and `correlation studies`.
 - **Portfolio Optimization**: Utilize sophisticated `sparse optimization` with Huber Downward Risk minimization, calculate performance, and benchmark strategies.
@@ -221,6 +221,7 @@ This MCP server is designed to be used with natural language. Below are examples
 | `create_project` | Create new QuantConnect project | `name`, `language`, `organization_id` |
 | `read_project` | Get project details or list all | `project_id` (optional) |
 | `update_project` | Update project name/description | `project_id`, `name`, `description` |
+| `compile_project` | Compile a project for backtesting | `project_id` |
 
 ### ◆ File Management Tools
 
@@ -280,7 +281,7 @@ This MCP server is designed to be used with natural language. Below are examples
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `create_backtest` | Create new backtest | `project_id`, `compile_id`, `backtest_name` |
+| `create_backtest` | Create new backtest from compile | `project_id`, `compile_id`, `backtest_name` |
 | `read_backtest` | Get backtest results | `project_id`, `backtest_id`, `chart` |
 | `read_backtest_chart` | Get chart data | `project_id`, `backtest_id`, `name` |
 | `read_backtest_orders` | Get order history | `project_id`, `backtest_id`, `start`, `end` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "scipy>=1.15.3",
     "seaborn>=0.13.2",
     "statsmodels>=0.14.4",
+    "quantconnect-lean",
+    "quantconnect>=0.1.0",
 ]
 
 [project.scripts]

--- a/quantconnect_mcp/src/tools/backtest_tools.py
+++ b/quantconnect_mcp/src/tools/backtest_tools.py
@@ -84,6 +84,14 @@ def register_backtest_tools(mcp: FastMCP):
                 else:
                     # API returned success=false
                     errors = data.get("errors", ["Unknown error"])
+                    if any("Compile id not found" in e for e in errors):
+                        return {
+                            "status": "error",
+                            "error": "Compile ID not found. Please compile the project first using the 'compile_project' tool.",
+                            "details": errors,
+                            "project_id": project_id,
+                            "compile_id": compile_id,
+                        }
                     return {
                         "status": "error",
                         "error": "Backtest creation failed",

--- a/uv.lock
+++ b/uv.lock
@@ -947,6 +947,24 @@ wheels = [
 ]
 
 [[package]]
+name = "quantconnect"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/2a/2762a4e3497d35830ac5122fd2bcb7f5fb996f7c8ea47a255c03378466ff/quantconnect-0.1.0.tar.gz", hash = "sha256:9c47411e925141112b40893e0ae1b9364e63b487ce710322cb031d57e022ffd2", size = 921, upload_time = "2020-06-19T21:59:54.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/30/6624de8b559a496cf34957c4bdb25622713754bcbdfefc06812ed841e92f/quantconnect-0.1.0-py3-none-any.whl", hash = "sha256:c134dcfaf628066932984bc28377c4d717658af108fc70e1f603e5c63856be15", size = 5313, upload_time = "2020-06-19T21:59:52.096Z" },
+]
+
+[[package]]
+name = "quantconnect-lean"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/b2/1224d53810b0f933ff0bf5ca6e01f3c36486fe3692cc70acb07e2ea816b3/quantconnect-lean-0.1.0.tar.gz", hash = "sha256:9142b085657c742ef7a9f82e6e391c6ff3ce3e563db7cd85aa9592e67897dfba", size = 936, upload_time = "2020-06-19T22:03:01.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/00/a9ac5615a5b6be182e7e95aa7cd9019e9f59a6bee3a4642a0b5b254c84db/quantconnect_lean-0.1.0-py3-none-any.whl", hash = "sha256:5364adaab7198866298c4a1ecfbc207dc676b545b03e0d75c05ac50cfd069569", size = 5368, upload_time = "2020-06-19T22:03:00.146Z" },
+]
+
+[[package]]
 name = "quantconnect-mcp"
 version = "0.1.7"
 source = { editable = "." }
@@ -959,6 +977,8 @@ dependencies = [
     { name = "pandas" },
     { name = "psutil" },
     { name = "pytest-asyncio" },
+    { name = "quantconnect" },
+    { name = "quantconnect-lean" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
@@ -985,6 +1005,8 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "quantconnect", specifier = ">=0.1.0" },
+    { name = "quantconnect-lean" },
     { name = "scikit-learn", specifier = ">=1.7.0" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "seaborn", specifier = ">=0.13.2" },


### PR DESCRIPTION
This PR focuses on improving the backtesting workflow and resolving critical dependency issues.

#### New Features

*   **`compile_project` Tool**: A new `compile_project` tool has been added to the project management tools. This allows for the compilation of a project, which is a necessary step to generate a `compile_id` required for running backtests.

#### Bug Fixes

*   **QuantBook Initialization Failure**: Resolved a critical bug where `QuantBook` would fail to initialize due to a missing `quantconnect-lean` dependency. This has been added to the project dependencies, and the lock file has been updated.
*   **Backtest Creation Error**: Fixed the "Compile id not found" error that occurred when creating a backtest. The new `compile_project` tool and improved error handling in the `create_backtest` tool now guide the user through the correct workflow.

#### Improvements

*   **Enhanced Error Handling**: The `create_backtest` tool now provides a more informative error message if an invalid `compile_id` is provided, directing the user to compile the project first.
*   **Updated Documentation**: The `README.md` has been updated to include the new `compile_project` tool in the API reference and feature list, and the example workflow has been updated to reflect the correct sequence of operations for backtesting.